### PR TITLE
Fix `pulls` link 404ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repo is an official experiment in how we create, contribute to, and define our microservice principles that run through Fresh8 Gaming.
 
-If you would like to look in more detail at what is going on, check the [pull requests](pulls) for current discussions, or the [contributing guidelines](CONTRIBUTING.md) for how to get involved in submitting proposals.
+If you would like to look in more detail at what is going on, check the [pull requests](https://github.com/fresh8/microservice-principles/pulls) for current discussions, or the [contributing guidelines](CONTRIBUTING.md) for how to get involved in submitting proposals.


### PR DESCRIPTION
There might be a way to use relative addresses... but I also kinda think this README could be displaying in other places in which case relative url path might be a bad idea?

If we say this though we should probably update the Contributing link too.